### PR TITLE
Add bbnorm 

### DIFF
--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -4,6 +4,7 @@ channels:
   - bioconda
 dependencies:
   - python=3
-  - fastp=0.23.2
-  - rasusa=0.7.0
+  - fastp=1.0.1
+  - rasusa=2.1.1
+  - bbmap=39.33
   - perl-digest-sha=5.88

--- a/main.nf
+++ b/main.nf
@@ -2,13 +2,13 @@
 
 nextflow.enable.dsl = 2
 
-include { hash_files as hash_fastq_input }  from './modules/hash_files.nf'
-include { hash_files as hash_fastq_output } from './modules/hash_files.nf'
-include { fastp as fastp_input }            from './modules/downsample_reads.nf'
-include { downsample }                      from './modules/downsample_reads.nf'
-include { fastp as fastp_output }           from './modules/downsample_reads.nf'
-include { pipeline_provenance }             from './modules/provenance.nf'
-include { collect_provenance }              from './modules/provenance.nf'
+include { hash_files as hash_fastq_input }          from './modules/hash_files.nf'
+include { hash_files as hash_fastq_output }         from './modules/hash_files.nf'
+include { fastp as fastp_input }                    from './modules/downsample_reads.nf'
+include { downsample_rasusa ; downsample_bbnorm }   from './modules/downsample_reads.nf'
+include { fastp as fastp_output }                   from './modules/downsample_reads.nf'
+include { pipeline_provenance }                     from './modules/provenance.nf'
+include { collect_provenance }                      from './modules/provenance.nf'
 
 workflow {
 
@@ -34,13 +34,24 @@ workflow {
     
     ch_fastp_input = ch_fastq.join(ch_coverages.map({ it -> [it[0], it[2]] }))
 
-    fastp_input(ch_fastp_input.combine(Channel.of("original")))
+    fastp = fastp_input(ch_fastp_input.combine(Channel.of("original")))
 
-    downsample(ch_fastq.join(ch_coverages))
+    if (params.use_filtered_reads) {
+        printf("Using filtered reads for downsampling.\n")
+        ch_fastq = fastp.filtered_reads
+    }
 
-    hash_fastq_output(downsample.out.reads.map{ it -> [it[0], it[3], it[1]] }.combine(Channel.of("fastq-output")))
+    if (params.tool == 'rasusa') {
+        ch_downsample = downsample_rasusa(ch_fastq.join(ch_coverages))
+    } else if (params.tool == 'bbnorm') {
+        ch_downsample = downsample_bbnorm(ch_fastq.join(ch_coverages))
+    } else {
+        error "ERROR: Invalid tool choice. Please choose either 'rasusa' or 'bbnorm'."
+    }
 
-    fastp_output(downsample.out.reads)
+    hash_fastq_output(ch_downsample.reads.map{ it -> [it[0], it[3], it[1]] }.combine(Channel.of("fastq-output")))
+
+    fastp_output(ch_downsample.reads)
 
     fastp_input.out.csv.concat(fastp_output.out.csv).map{ it -> it[1] }.collectFile(name: params.collected_outputs_prefix + "_downsampling_summary.csv", storeDir: params.outdir, keepHeader: true, skip: 1, sort: { it -> it[0] })
 
@@ -55,7 +66,7 @@ workflow {
     ch_provenance = ch_provenance.combine(ch_pipeline_provenance).map({ it -> [it[0], it[1], [it[2]]] })
     ch_provenance = ch_provenance.join(hash_fastq_input.out.provenance, by: [0, 1]).map{ it -> [it[0], it[1], it[2] << it[3]] }
     ch_provenance = ch_provenance.join(fastp_input.out.provenance).map{ it -> [it[0], it[1], it[2] << it[4]] }
-    ch_provenance = ch_provenance.join(downsample.out.provenance, by: [0, 1]).map{ it -> [it[0], it[1], it[2] << it[3]] }
+    ch_provenance = ch_provenance.join(ch_downsample.provenance, by: [0, 1]).map{ it -> [it[0], it[1], it[2] << it[3]] }
     ch_provenance = ch_provenance.join(hash_fastq_output.out.provenance, by: [0, 1]).map{ it -> [it[0], it[1], it[2] << it[3]] }
 
     collect_provenance(ch_provenance.map{ it -> [it[0], it[1], it[2].minus(null)] })

--- a/modules/downsample_reads.nf
+++ b/modules/downsample_reads.nf
@@ -3,7 +3,6 @@ process fastp {
     tag { sample_id + ' / ' + target_coverage_filename }
 
     publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}_${target_coverage_filename}_downsampling_summary.csv", mode: 'copy'
-    // publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}_R*.trim.fastq.gz", mode: 'copy', enabled: params.use_filtered_reads
 
     input:
     tuple val(sample_id), path(reads), val(genome_size), val(target_coverage)

--- a/modules/downsample_reads.nf
+++ b/modules/downsample_reads.nf
@@ -72,13 +72,13 @@ process downsample_rasusa {
 
     tag { sample_id + ' / ' + genome_size + ' / ' + coverage + 'x' }
 
-    publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}-downsample-rasusa-*x_R*.fastq.gz", mode: 'copy'
+    publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}_downsample-rasusa-*x_R*.fastq.gz", mode: 'copy'
 
     input:
     tuple val(sample_id), path(reads), val(coverage), val(genome_size)
 
     output:
-    tuple val(sample_id), path("${sample_id}-downsample-rasusa-*x_R*.fastq.gz"), val(genome_size), val(coverage), emit: reads
+    tuple val(sample_id), path("${sample_id}_downsample-rasusa-*x_R*.fastq.gz"), val(genome_size), val(coverage), emit: reads
     tuple val(sample_id), val(coverage), path("${sample_id}_${coverage}x_downsample_provenance.yml"), emit: provenance
 
     script:
@@ -101,8 +101,8 @@ process downsample_rasusa {
         --genome-size ${genome_size} \
         ${reads[0]} \
         ${reads[1]} \
-        -o ${sample_id}-downsample-rasusa-${coverage}x_R1.fastq.gz \
-        -o ${sample_id}-downsample-rasusa-${coverage}x_R2.fastq.gz
+        -o ${sample_id}_downsample-rasusa-${coverage}x_R1.fastq.gz \
+        -o ${sample_id}_downsample-rasusa-${coverage}x_R2.fastq.gz
     """
 }
 
@@ -110,13 +110,13 @@ process downsample_bbnorm {
 
     tag { sample_id + ' / ' + genome_size + ' / ' + coverage + 'x' }
 
-    publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}-downsample-*x_R*.fastq.gz", mode: 'copy'
+    publishDir "${params.outdir}/${sample_id}", pattern: "${sample_id}_downsample-*x_R*.fastq.gz", mode: 'copy'
 
     input:
     tuple val(sample_id), path(reads), val(coverage), val(genome_size)
 
     output:
-    tuple val(sample_id), path("${sample_id}-downsample-bbnorm-*x_R*.fastq.gz"), val(genome_size), val(coverage), emit: reads
+    tuple val(sample_id), path("${sample_id}_downsample-bbnorm-*x_R*.fastq.gz"), val(genome_size), val(coverage), emit: reads
     tuple val(sample_id), val(coverage), path("${sample_id}_${coverage}x_downsample_provenance.yml"), emit: provenance
 
     script:
@@ -135,13 +135,13 @@ process downsample_bbnorm {
         -Xmx${max_memory_gb}g \
         in1=${reads[0]} \
         in2=${reads[1]} \
-        out1=${sample_id}-downsample-bbnorm-${coverage}x_R1.fastq \
-        out2=${sample_id}-downsample-bbnorm-${coverage}x_R2.fastq \
+        out1=${sample_id}_downsample-bbnorm-${coverage}x_R1.fastq \
+        out2=${sample_id}_downsample-bbnorm-${coverage}x_R2.fastq \
         target=${params.coverage} \
 	
 
-    gzip ${sample_id}-downsample-bbnorm-${coverage}x_R1.fastq
-    gzip ${sample_id}-downsample-bbnorm-${coverage}x_R2.fastq
+    gzip ${sample_id}_downsample-bbnorm-${coverage}x_R1.fastq
+    gzip ${sample_id}_downsample-bbnorm-${coverage}x_R2.fastq
 
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,10 +18,12 @@ params {
     coverage = 30
     genome_size = '5m'
     random_seed = 0
+    tool = 'rasusa'
     enable_quality_trimming = false
     disable_quality_filtering = false
     collect_outputs = false
     collected_outputs_prefix = 'collected'
+    use_filtered_reads = false
 }
 
 def makeFastqSearchPath(illumina_suffixes, fastq_exts) {
@@ -73,6 +75,10 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 process {
     withName: fastp {
 	cpus = 4
+    }
+
+    withName: downsample_bbnorm {
+        memory = '4 GB' 
     }
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,6 +16,7 @@ params {
     samplesheet_input = 'NO_FILE'
     coverages = 'NO_FILE'
     coverage = 30
+    cache = ''
     genome_size = '5m'
     random_seed = 0
     tool = 'rasusa'

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,7 @@
 manifest {
     author = 'Dan Fornika'
     name = 'BCCDC-PHL/downsample-reads'
-    version = '0.2.2'
+    version = '0.3.0'
     description = 'Downsample Reads'
     mainScript = 'main.nf'
     nextflowVersion = '>=20.01.0'

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,7 +61,7 @@ profiles {
     }
     apptainer {
         apptainer.enabled = true
-        process.container = "oras://ghcr.io/bccdc-phl/downsample-reads:bd6055c017ff8255"
+        process.container = "oras://ghcr.io/bccdc-phl/downsample-reads:41a7fa68a9aeb410"
 
 	if (params.cache){
             apptainer.cacheDir = params.cache

--- a/nextflow.config
+++ b/nextflow.config
@@ -74,7 +74,7 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 
 process {
     withName: fastp {
-	cpus = 4
+        cpus = 4
     }
 
     withName: downsample_bbnorm {


### PR DESCRIPTION
Resolves: #27
Resolves: #26 

## Added bbnorm 

- added new Nextflow process for bbnorm 
- added bbnorm to conda `environment.yaml` 
- added new parameter `tool` to control the downsampler being used (default: `rasusa`) 

## Added ability to use filtered reads
- added new parameter `use_filtered_reads` controlling a logic block in `main.nf` (defaut: false)
- when turned on, will pipe fastp filtered reads into downsampling tool input

## Uncertain Areas for Review  
- currently, I upgraded the versions of `fastp` and `rasusa` being used in the pipeline
  - I realize this would change any current environments being used in production
- currently, I also renamed the `rasusa` downsampled FASTQ filenames to include "rasusa" in the name 
  - might cause problems when globbing files 
- **happy to revert either of these changes if we are concerned about compatibility**